### PR TITLE
Fix: load_signer_certificates

### DIFF
--- a/playbooks/base/load_signer_certificates.yml
+++ b/playbooks/base/load_signer_certificates.yml
@@ -1,14 +1,8 @@
 ---
-# Load
-#   load signer certificates into certificate store
-#   Example:
-#      load_signer_certificates:
-#         -   kdb_id: pdsrv
-#             label:  local runtime
-#             server: localhost
-#             port:   443
+# load_signer_certificates
+#   load signer certificates into corresponding certificate store
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.base/load_signer_certificates
+    - role: ibm.isam.base.load_signer_certificates
       tags: load_signer_certificates

--- a/roles/base/load_signer_certificates/defaults/main.yml
+++ b/roles/base/load_signer_certificates/defaults/main.yml
@@ -1,2 +1,12 @@
-# Default variables for seamless integration
+# load_signer_certificates default variables
 load_signer_certificates: []
+
+# filter to limit role execution at runtime
+kdb_id: "{{ item.kdb_id }}" 
+label: "{{ item.label }}"
+server: "{{ item.server }}" 
+
+# comparing certificates is supported in two modes: simple(default) & advanced
+# simple[check_remote=false] only checks if label already exists in appliance kdb
+# advanced[check_remote=true] retrieving server certificate and compare with appliance certificate content
+check_remote: false

--- a/roles/base/load_signer_certificates/tasks/main.yml
+++ b/roles/base/load_signer_certificates/tasks/main.yml
@@ -1,5 +1,52 @@
-# main task: load_signer_certificates
 ---
+- name: Help INFO (-e help=true)
+  pause:
+    echo: yes
+    prompt: |
+      NAME
+        load_signer_certificates
+      
+      DESCRIPTION
+        Role to load a signer certificate into a certificate store
+      
+      STEPS
+        1) load signer certificate from remote server into certificate store
+        2) commit changes
+      
+      EXAMPLES
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e label=isam-openldap // filter to load only certificates with matching label at runtime
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e kdb_id=pdsrv // filter to load only certificates which should end in the corresponding certificate store at runtime
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e server=isam-ldap.ibm.com // filter to load only certificates from matching remote server
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e server=isam-ldap.ibm.com -e label=isam-openldap // any combination possible
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e check_remote=True // overwrite compare mode to advanced. Comparing remote server certificate with appliance certificate data in keystore. Attention: ansible needs to be able to access remote server for this.
+        ansible-playbook -i [...] playbooks/ansible_collections/base/load_signer_certificates.yml -e force=True // overwrite comparison and load certificates again from remote servers
+      
+      INVENTORY
+      ==========
+      # enable FIPS mode by default
+      load_signer_certificates:
+        - kdb_id: pdsrv
+          label: isam-openldap
+          server: isam-ldap.ibm.com
+          port: 636
+        - kdb_id: pdsrv
+          label: local runtime
+          server: localhost
+          port: 443
+        - kdb_id: pdsrv
+          label: secret_backend
+          server: example.secret.com
+          port: 1337
+          check_remote: True # overwrite default check_remote only for this certificate. ! can't be overwritten at runtime again
+      ==========
+      
+      INTERACTION
+        ENTER         = continue
+        Ctrl+C + 'C'  = continue
+        Ctrl+C + 'A'  = abort
+  when: help is defined
+
 - name: Load signer certificates into certificate store
   ibm.isam.isam:
     log: "{{ log_level | default(omit) }}"
@@ -10,5 +57,7 @@
       label: "{{ item.label }}"
       server: "{{ item.server }}"
       port: "{{ item.port }}"
+      check_remote: "{{ item.check_remote | default(check_remote) }}"
+  when: item.label == label and item.kdb_id == kdb_id and item.server == server
   with_items: "{{ load_signer_certificates }}"
   notify: Commit Changes


### PR DESCRIPTION
playbook:
  - fix role path
role:
  - add help messages
  - adding default for check_remote=False (simple or advanced remote server certificate comparison)
    simple: check only if label already exists in kdb
    advanced: check appliance and remote certificate data
 - add filter for kdb_id and server