### PR TITLE
Bug-Fix: Undefined variable check

### DIFF
--- a/roles/base/configure_interfaces/tasks/main.yml
+++ b/roles/base/configure_interfaces/tasks/main.yml
@@ -74,7 +74,7 @@
     filter_current_interfaces: "interfaces[].{label: label,addresses: ipv4.addresses[].address}"
   set_fact:
     addresses_list_server: "{{ ret_obj.data | json_query(filter_current_interfaces) }}"
-  when: ret_obj is defined and ret_obj.data != []
+  when: ret_obj.data is defined and ret_obj.data != []
 
 - vars:
     filter_current_interfaces: "[? label=='{{ item.0.label }}'].addresses[].address"


### PR DESCRIPTION
Running the playbook/role without "-e configure_interfaces_delete_missing=True" skips filling of variable ret_obj with appliance interfaces resulting in error "The conditional check 'ret_obj.data != []' failed. The error was: error while evaluating conditional (ret_obj.data != []): 'dict object' has no attribute 'data'"

Conditional check only needs to check for dict sub-element data.

Following checks have been done:
- running playbook with and without "-e configure_interfaces_delete_missing=True"
- running playbook with "-e configure_interfaces_delete_missing=True" and an additional ipv4 address on an appliance which was successfully deleted