### PR TITLE
BugFix: [false positives] Increase command timeout

### DIFF
--- a/roles/base/activate_modules/defaults/main.yml
+++ b/roles/base/activate_modules/defaults/main.yml
@@ -2,3 +2,6 @@
 
 # id to filter activations at runtime
 id: "{{ item.id }}"
+
+# increase command timeout, otherwise task will indicate failure although modules are activated [false positives]
+ansible_command_timeout: 120


### PR DESCRIPTION
Without increased command timeout following error is often raised because appliance didn't respond within default command timeout (30s):  `An exception occurred during task execution. To see the full traceback, use -vvv. The error was: See the timeout setting options in the Network Debug and Troubleshooting Guide.
[...]
ansible.module_utils.connection.ConnectionError: command timeout triggered, timeout value is 30 secs.
[...]
`

Higher timeout's (because of network latency or slower appliances) should be increased by manually overwriting the default command timeout through inventory variables or environment variables.  Review plugins\connection\isam.py DOCUMENTATION section for details.