### PR TITLE
+role/playbook: configure_dns

### DIFF
--- a/playbooks/base/configure_dns.yml
+++ b/playbooks/base/configure_dns.yml
@@ -1,0 +1,8 @@
+---
+# Configure
+#   configure dns settings
+- hosts: "{{ hosts | default('all')}}"
+  gather_facts: no
+  roles:
+    - role: ibm.isam.base.configure_dns
+      tags: configure_dns

--- a/roles/base/configure_dns/defaults/main.yml
+++ b/roles/base/configure_dns/defaults/main.yml
@@ -1,0 +1,1 @@
+# default variables to configure dns

--- a/roles/base/configure_dns/meta/main.yml
+++ b/roles/base/configure_dns/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to configure dns settings
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - configure
+  - dns
+
+dependencies:
+  - common_handlers

--- a/roles/base/configure_dns/tasks/main.yml
+++ b/roles/base/configure_dns/tasks/main.yml
@@ -1,0 +1,55 @@
+# main task to configure dns
+- name: Help INFO (-e help=true)
+  pause:
+    echo: yes
+    prompt: |
+      NAME
+        configure_dns
+      
+      DESCRIPTION
+        Role to configure dns
+      
+      STEPS
+        1) Configure dns
+        2) Commit changes
+      
+      EXAMPLES
+        ansible-playbook -i [...] playbooks/ansible_collections/base/configure_dns.yml
+      
+      INVENTORY
+      ==========
+      # configure dns
+      # AUTO (set via DHCP of Interface)
+      dns:
+        auto: true
+        autoFromInterface: '1.1'
+      
+      # AUTO (set via DHCP of loopback Interface)
+      dns:
+        auto: true
+        autoFromInterface: 'loopback'
+      
+      # Manual with only primary DNS
+      dns:
+        primaryServer: 192.168.42.1
+        auto: false
+      
+      # AUTO (set via DHCP of Interface with Interface UUID)
+      dns:
+        auto: true
+        autoFromInterface: '<UUID>' e.g.('b702f799-c305-4439-8835-4e51c9b6d16b')
+      ==========
+      
+      INTERACTION
+        ENTER         = continue
+        Ctrl+C + 'C'  = continue
+        Ctrl+C + 'A'  = abort
+  when: help is defined
+- name: Configure dns
+  ibm.isam.isam:
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: "ibmsecurity.isam.base.network.dns.set"
+    isamapi: "{{ dns }}"
+  when: dns is defined
+  notify: Commit Changes


### PR DESCRIPTION
New Role and Playbook to configure dns.
The feature to use interface label instead of UUID depends on ibmsecurity pull request : https://github.com/IBM-Security/ibmsecurity/pull/264