### PR TITLE
Fix: import_keytab_files

### DIFF
--- a/playbooks/web/import_keytab_files.yml
+++ b/playbooks/web/import_keytab_files.yml
@@ -1,10 +1,7 @@
 ---
 # playbook to import kerberos keytab files
-# Example:
-#   import_keytab_files:
-#     - file: uploads/kerberos/kerberos.krb5
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.web/import_keytab_files
+    - role: ibm.isam.web.import_keytab_files
       tags: import_keytab_files

--- a/roles/web/import_keytab_files/defaults/main.yml
+++ b/roles/web/import_keytab_files/defaults/main.yml
@@ -1,0 +1,4 @@
+# default values to import kerberos keytab files
+keytab_files: []
+
+name: "{{ item.file | basename }}"

--- a/roles/web/import_keytab_files/meta/main.yml
+++ b/roles/web/import_keytab_files/meta/main.yml
@@ -1,0 +1,17 @@
+galaxy_info:
+  author: IBM
+  description: Role to import kerberos keytab files
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: 2.2
+
+  galaxy_tags:
+  - isam
+  - ibm
+  - import
+  - keytab_files
+
+dependencies:
+  - common_handlers

--- a/roles/web/import_keytab_files/tasks/main.yml
+++ b/roles/web/import_keytab_files/tasks/main.yml
@@ -1,0 +1,47 @@
+---
+- name: Help INFO (-e help=true)
+  pause:
+    echo: yes
+    prompt: |
+      NAME
+        import_keytab_files
+      
+      DESCRIPTION
+        Role to import multiple kerberos keytab files
+      
+      STEPS
+        1) import multiple kerberos keytab files
+        2) Commit changes
+      
+      EXAMPLES
+        ansible-playbook -i [...] playbooks/ansible_collections/web/import_keytab_files.yml 
+        ansible-playbook -i [...] playbooks/ansible_collections/web/import_keytab_files.yml -e name=default.krb5 // limit import to a specific file from inventory !ATTENTION!: only basename from path variable is used for filtering
+      
+      INVENTORY
+      ==========
+      # import multiple kerberos keytbal files
+      # !ATTENTION! ibmsecurity library supports id + file parameter but appliance REST API does not support that the same file with different id is imported
+      # Therefore relying only on file parameter for this role
+      keytab_files:
+        - file: files/kerberos/default.krb5
+        - file: /ansible/inventory/simple/files/kerberos/another.krb5
+      ==========
+      
+      INTERACTION
+        ENTER         = continue
+        Ctrl+C + 'C'  = continue
+        Ctrl+C + 'A'  = abort
+  when: help is defined
+- name: Import kerberos keytab files
+  ibm.isam.isam:
+    log:       "{{ log_level | default(omit) }}"
+    force:     "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.web.kerberos_configuration.keyfiles.import_keytab
+    isamapi:
+      id: "{{ item.file | basename }}"
+      file: "{{ item.file if((item.file | regex_search('^/')) == '/') else (inventory_dir +'/'+ item.file) }}"
+  when: item.file is defined and (item.file | basename) == name
+  with_items: "{{ keytab_files }}"
+  loop_control:
+    label: "{ id: \"{{ item.file | basename }}\", file: \"{{ item.file }}\" }"
+  notify: Commit Changes


### PR DESCRIPTION
playbook:
 - correct role path
 - remove example -> now via help function in role
role:
 - adding missing role
 - adding help message
 - adding support for relative and absolute file paths
 - correct loop label