### PR TITLE
BugFix: when on vars_prompt not supported

### DIFF
--- a/playbooks/base/change_admin_password.yml
+++ b/playbooks/base/change_admin_password.yml
@@ -9,12 +9,10 @@
       prompt: "What is your current admin password [LMI]?"
       private: yes
       confirm: no
-      when: help is not defined
     - name: new_password
       prompt: "What is your desired new admin password [LMI]?"
       private: yes
       confirm: yes
-      when: help is not defined
   roles:
     - role: ibm.isam.base.change_admin_password
       tags: change_admin_password


### PR DESCRIPTION
new ansible 2.10.x will raise an error if 'when' is used on vars_prompt in the playbook change_admin_password.
vars_prompt already skips vars provided via --extra-vars (-e old_password or -e new_password)