### PR TITLE
DocumentationFix: default gw metric is 0

### DIFF
--- a/roles/base/configure_static_routes/tasks/main.yml
+++ b/roles/base/configure_static_routes/tasks/main.yml
@@ -29,7 +29,7 @@
         - route_action: set
           address: default
           gateway: '192.168.42.2'
-          metric: 1
+          metric: 0
           label: '1.1'
         - route_action: set
           address: '192.168.42.6'


### PR DESCRIPTION
Default value on metrics for a default gateway should be 0 and not 1.

This change has no impact on the functionality.