### PR TITLE
Fix: configure_advanced_tuning_parameters

### DIFF
--- a/playbooks/base/configure_advanced_tuning_parameters.yml
+++ b/playbooks/base/configure_advanced_tuning_parameters.yml
@@ -1,16 +1,8 @@
 ---
 # Configure
 #   configure advanced tuning parameters
-#   Example:
-#     advanced_tuning_parameters:
-#       - action: set
-#         key: test
-#         value: HelloWorld
-#         comment: this is a test tuning parameter
-#       - action: delete
-#         key: test
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.base/configure_advanced_tuning_parameters
+    - role: ibm.isam.base.configure_advanced_tuning_parameters
       tags: configure_advanced_tuning_parameters

--- a/roles/base/configure_advanced_tuning_parameters/defaults/main.yml
+++ b/roles/base/configure_advanced_tuning_parameters/defaults/main.yml
@@ -2,3 +2,6 @@
 
 # default variables for configuration of advanced tuning parameters
 advanced_tuning_parameters: []
+
+# filter at runtime for specific advanced tuning parameters
+key: "{{ item.key }}"

--- a/roles/base/configure_advanced_tuning_parameters/tasks/main.yml
+++ b/roles/base/configure_advanced_tuning_parameters/tasks/main.yml
@@ -1,11 +1,48 @@
 ---
 
 # main task to configure advanced tuning parameters
-- name: Configure advanced tuning parameters
+
+- name: Help INFO (-e help=true)
+  pause:
+    echo: yes
+    prompt: |
+      NAME
+        configure_advanced_tuning_parameters
+
+      DESCRIPTION
+        Role to configure advanced tuning parameters
+
+      STEPS
+        1) configure advanced tuning parameters
+        2) Commit changes
+
+      EXAMPLES
+        ansible-playbook -i [...] playbooks/ansible_collections/base/configure_advanced_tuning_parameters.yml 
+
+      INVENTORY
+      ==========
+      advanced_tuning_parameters:
+        - tuning_action: set
+          key: test
+          value: HelloWorld
+          comment: this is a test tuning parameter
+        - tuning_action: delete
+          key: test
+      ==========
+
+      INTERACTION
+        ENTER         = continue
+        Ctrl+C + 'C'  = continue
+        Ctrl+C + 'A'  = abort
+  when: help is defined
+
+- name: Configure advanced tuning parameters [-e key=<key_1>]
   ibm.isam.isam:
     log: "{{ log_level | default(omit) }}"
     force: "{{ force | default(omit) }}"
-    action: "ibmsecurity.isam.base.advanced_tuning_parameters.{{ item.action }}"
-    isamapi: "{{ item | exclude('action') }}"
-  with_items: "{{ advanced_tuning_parameters }}"
+    action: "ibmsecurity.isam.base.advanced_tuning_parameters.{{ item.tuning_action }}"
+    isamapi: "{{ item | ibm.isam.exclude('tuning_action') }}"
+  loop: "{{ advanced_tuning_parameters }}"
+  when: 
+    - item.key == key
   notify: Commit Changes


### PR DESCRIPTION
playbook:
 - correct role path
 - remove example -> now via help function in role
role:
 - help message
 - filter for key at runtime