### PR TITLE
Fix: configure_api_protection_definitions inventory structure

### DIFF
--- a/playbooks/aac/configure_api_protection_definitions.yml
+++ b/playbooks/aac/configure_api_protection_definitions.yml
@@ -12,5 +12,5 @@
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.aac/configure_api_protection_definitions
+    - role: ibm.isam.aac.configure_api_protection_definitions
       tags: configure_api_protection_definitions

--- a/roles/aac/configure_api_protection_definitions/molecule/add/converge.yml
+++ b/roles/aac/configure_api_protection_definitions/molecule/add/converge.yml
@@ -7,7 +7,8 @@
       include_role:
         name: "configure_api_protection_definitions"
       vars:
-        api_protection_definitions:
-          - name: "{{ definition_name }}"
-            description: "{{ description }}"
-            tcmBehavior: "{{ tcmBehavior }}"
+        api_protection:
+          definitions:
+            - name: "{{ molecule_definition_name }}"
+              description: "{{ molecule_description }}"
+              tcmBehavior: "{{ molecule_tcmBehavior }}"

--- a/roles/aac/configure_api_protection_definitions/molecule/add/verify.yml
+++ b/roles/aac/configure_api_protection_definitions/molecule/add/verify.yml
@@ -12,10 +12,10 @@
       include_role:
         name: "get_api_protection_definitions"
       vars:
-        get_api_protection_definitions: "{{ inventory.definitions }}"
+        get_api_protection_definitions: "{{ inventory.molecule_definitions }}"
 
-    - name: "Assert that the client {{ inventory.definition_name }} was added"
+    - name: "Assert that the client {{ inventory.molecule_definition_name }} was added"
       assert:
-        that: ret_obj.results.0.data.name == inventory.definition_name
-        fail_msg: "API Protection definition {{ inventory.definition_name }} was not added"
-        success_msg: "API Protection definition {{ inventory.definition_name }} was added"
+        that: ret_obj.results.0.data.name == inventory.molecule_definition_name
+        fail_msg: "API Protection definition {{ inventory.molecule_definition_name }} was not added"
+        success_msg: "API Protection definition {{ inventory.molecule_definition_name }} was added"

--- a/roles/aac/configure_api_protection_definitions/molecule/update/converge.yml
+++ b/roles/aac/configure_api_protection_definitions/molecule/update/converge.yml
@@ -7,6 +7,7 @@
       include_role:
         name: "configure_api_protection_definitions"
       vars:
-        api_protection_definitions:
-          - name: "{{ definition_name }}"
-            description: "{{ update_description }}"
+        api_protection:
+          definitions:
+            - name: "{{ molecule_definition_name }}"
+              description: "{{ molecule_update_description }}"

--- a/roles/aac/configure_api_protection_definitions/molecule/update/verify.yml
+++ b/roles/aac/configure_api_protection_definitions/molecule/update/verify.yml
@@ -12,12 +12,12 @@
       include_role:
         name: "get_api_protection_definitions"
       vars:
-        get_api_protection_definitions: "{{ inventory.definitions }}"
+        get_api_protection_definitions: "{{ inventory.molecule_definitions }}"
 
-    - name: "Assert that the client {{ inventory.definition_name }} was added"
+    - name: "Assert that the client {{ inventory.molecule_definition_name }} was added"
       assert:
         that:
-          - ret_obj.results.0.data.name == inventory.definition_name
-          - ret_obj.results.0.data.description == inventory.update_description
-        fail_msg: "API Protection definition {{ inventory.definition_name }} was not updated"
-        success_msg: "API Protection definition {{ inventory.definition_name }} was updated"
+          - ret_obj.results.0.data.name == inventory.molecule_definition_name
+          - ret_obj.results.0.data.description == inventory.molecule_update_description
+        fail_msg: "API Protection definition {{ inventory.molecule_definition_name }} was not updated"
+        success_msg: "API Protection definition {{ inventory.molecule_definition_name }} was updated"

--- a/roles/aac/configure_api_protection_definitions/tasks/main.yml
+++ b/roles/aac/configure_api_protection_definitions/tasks/main.yml
@@ -14,7 +14,7 @@
     log: "{{ log_level | default(omit) }}"
     force: "{{ force | default(omit) }}"
     action: ibmsecurity.isam.aac.api_protection.definitions.set
-    isamapi: "{{ item }}"
-  with_items: "{{ api_protection_definitions }}"
+    isamapi: "{{ item | ibm.isam.exclude('clients') | ibm.isam.exclude('mapping_rules') }}"
+  with_items: "{{ api_protection.definitions | default([]) }}"
   when: item.name == name
   notify: Commit Changes

--- a/roles/aac/configure_api_protection_definitions/vars/main.yml
+++ b/roles/aac/configure_api_protection_definitions/vars/main.yml
@@ -1,8 +1,8 @@
 ---
 
-definition_name: testapi4
-description: API protection for OAuth service provider
-tcmBehavior: NEVER_PROMPT
-update_description: updated description
-definitions:
+molecule_definition_name: testapi4
+molecule_description: API protection for OAuth service provider
+molecule_tcmBehavior: NEVER_PROMPT
+molecule_update_description: updated description
+molecule_definitions:
   - name: testapi4


### PR DESCRIPTION
QuickFix:
- playbook role path corrected
- role inventory structure corrected (api_protection_definitions -> api_protection.definitions) (review: https://github.com/IBM-Security/isam-ansible-roles/tree/master/aac/configure_api_protection_definitions)
 - molecule testing modified to meet previous inventory structure