### PR TITLE
Fix: configure_api_protection_clients inventory structure

### DIFF
--- a/playbooks/aac/configure_api_protection_clients.yml
+++ b/playbooks/aac/configure_api_protection_clients.yml
@@ -17,5 +17,5 @@
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.aac/configure_api_protection_clients
+    - role: ibm.isam.aac.configure_api_protection_clients
       tags: configure_api_protection_clients

--- a/roles/aac/configure_api_protection_clients/defaults/main.yml
+++ b/roles/aac/configure_api_protection_clients/defaults/main.yml
@@ -1,1 +1,3 @@
 ---
+
+client_name: "{{ item.1.name }}"

--- a/roles/aac/configure_api_protection_clients/molecule/add/converge.yml
+++ b/roles/aac/configure_api_protection_clients/molecule/add/converge.yml
@@ -7,10 +7,7 @@
       include_role:
         name: "configure_api_protection_clients"
       vars:
-        api_protection_clients:
-          - name: "{{ client_name }}"
-            companyName: "{{ companyName }}"
-            redirectUri: "{{ redirectUri }}"
-            contactType: "{{ contactType }}"
-            definitionName: "{{ definition_name }}"
-            description: "{{ description }}"
+        api_protection:
+          definitions:
+            - name: "{{ molecule.definition_name }}"
+              clients: "{{ molecule.clients }}"

--- a/roles/aac/configure_api_protection_clients/molecule/add/verify.yml
+++ b/roles/aac/configure_api_protection_clients/molecule/add/verify.yml
@@ -12,12 +12,12 @@
       include_role:
         name: "get_api_protection_clients"
       vars:
-        get_api_protection_clients: "{{ inventory.clients }}"
+        get_api_protection_clients: "{{ inventory.molecule_clients }}"
 
-    - name: "Assert that the client {{ inventory.client_name }} was added"
+    - name: "Assert that the client {{ inventory.molecule_client_name }} was added"
       assert:
         that:
           - ret_obj.results.0.data.name is defined
-          - ret_obj.results.0.data.name == inventory.client_name
-        fail_msg: "API Protection client {{ inventory.client_name }} was not added"
-        success_msg: "API Protection client {{ inventory.client_name }} was added"
+          - ret_obj.results.0.data.name == inventory.molecule_client_name
+        fail_msg: "API Protection client {{ inventory.molecule_client_name }} was not added"
+        success_msg: "API Protection client {{ inventory.molecule_client_name }} was added"

--- a/roles/aac/configure_api_protection_clients/molecule/update/converge.yml
+++ b/roles/aac/configure_api_protection_clients/molecule/update/converge.yml
@@ -7,10 +7,7 @@
       include_role:
         name: "configure_api_protection_clients"
       vars:
-        api_protection_clients:
-          - name: "{{ client_name }}"
-            companyName: "{{ companyName }}"
-            redirectUri: "{{ redirectUri }}"
-            contactType: "{{ contactType }}"
-            definitionName: "{{ definition_name }}"
-            companyUrl: "{{ companyUrl }}"
+        api_protection:
+          definitions:
+            - name: "{{ molecule.definition_name }}"
+              clients: "{{ molecule.clients_updated }}"

--- a/roles/aac/configure_api_protection_clients/molecule/update/verify.yml
+++ b/roles/aac/configure_api_protection_clients/molecule/update/verify.yml
@@ -12,17 +12,17 @@
       include_role:
         name: "get_api_protection_clients"
       vars:
-        get_api_protection_clients: "{{ inventory.clients }}"
+        get_api_protection_clients: "{{ inventory.molecule_clients }}"
 
     - debug:
         var: ret_obj
 
-    - name: "Assert that policy {{ inventory.client_name }} is added"
+    - name: "Assert that policy {{ inventory.molecule_client_name }} is added"
       assert:
         that:
           - ret_obj.results.0.data.name is defined
           - ret_obj.results.0.data.companyUrl is defined
-          - ret_obj.results.0.data.name == inventory.client_name
-          - ret_obj.results.0.data.companyUrl  == inventory.companyUrl
-        fail_msg: "API Protection client {{ inventory.client_name }} was not updated"
-        success_msg: "API Protection client {{ inventory.client_name }} was updated"
+          - ret_obj.results.0.data.name == inventory.molecule_client_name
+          - ret_obj.results.0.data.companyUrl  == inventory.molecule_companyUrl
+        fail_msg: "API Protection client {{ inventory.molecule_client_name }} was not updated"
+        success_msg: "API Protection client {{ inventory.molecule_client_name }} was updated"

--- a/roles/aac/configure_api_protection_clients/tasks/main.yml
+++ b/roles/aac/configure_api_protection_clients/tasks/main.yml
@@ -2,32 +2,31 @@
 
 # main task to add or update api protection client
 #   Example:
-#           clients:
+#     api_protection:
+#       definitions:
+#         - name: oauth-provider
+#           description: API protection for OAuth service provider
+#           grantTypes:
+#             - AUTHORIZATION_CODE
+#           tcmBehavior: NEVER_PROMPT
+#           clients: 
 #             - name: TestApp
-#               definitionName:
-#               companyName:
-#               redirectUri:
-#               companyUrl:
-#               contactPerson:
-#               contractType:
-#               email:
-#               phone:
-#               otherInfo:
-#               clientId:
-#               clientSecret:
-#               new_name:
-#               requirePkce:
-#               encryptionDb:
-#               encryptionCert:
-#               jwksUri:
-#               extProperties:
-#               introspectWithSecret:
+#               companyName: IBM demo client for OAuth flows
+#               redirectUri: 
+#                 - https://localhost
+#               contractType: ADMINISTRATIVE
 
 - name: Configure api protection client
   ibm.isam.isam:
     log: "{{ log_level | default(omit) }}"
     force: "{{ force | default(omit) }}"
     action: ibmsecurity.isam.aac.api_protection.clients.set
-    isamapi: "{{ item }}"
-  with_items: "{{ api_protection_clients }}"
+    isamapi: "{{ item.1 | combine({ 'definitionName': item.0.name }) }}"
+  when: item.1.name == client_name
+  with_subelements: 
+    - "{{ api_protection.definitions | default([])}}"
+    - clients
+    - skip_missing: True
+  loop_control:
+    label: "{ 'definitionName': {{ item.0.name }}, 'client_name': {{ item.1.name }} }"
   notify: Commit Changes

--- a/roles/aac/configure_api_protection_clients/vars/main.yml
+++ b/roles/aac/configure_api_protection_clients/vars/main.yml
@@ -1,12 +1,19 @@
 ---
 
-definition_name: testapi1
-grantTypes: AUTHORIZATION_CODE
-tcmBehavior: NEVER_PROMPT
-client_name: TestApp
-companyName: IBM demo client for OAuth flows
-redirectUri: https://localhost
-contactType: ADMINISTRATIVE
-clients:
+molecule.name: testapi1
+molecule.clients:
   - name: TestApp
-companyUrl: https://ibm.com
+    companyName: IBM demo client for OAuth flows
+    redirectUri:
+      - https://localhost
+    contractType: ADMINISTRATIVE
+molecule.clients_updated:
+  - name: TestApp
+    companyName: IBM demo client for OAuth flows
+    redirectUri:
+      - https://localhost
+    contractType: ADMINISTRATIVE
+    companyUrl: https://ibm.com
+
+molecule_client_name: TestApp
+molecule_companyUrl: https://ibm.com


### PR DESCRIPTION
QuickFix:
- playbook role path corrected
- role inventory structure corrected (api_protection_definitions -> api_protection.definitions & api_protection_clients -> clients inside api_protection.definitions) (review: https://github.com/IBM-Security/isam-ansible-roles/tree/master/aac/configure_api_protection_clients)
- molecule testing modified to meet previous inventory structure