### PR TITLE
Fix in isamcompare.py and new Ignore files

### DIFF
--- a/plugins/modules/isamcompare.py
+++ b/plugins/modules/isamcompare.py
@@ -87,7 +87,8 @@ from ansible.module_utils.basic import AnsibleModule
 from io import StringIO
 import datetime
 from ansible.module_utils.six import string_types
-from ansible.errors import AnsibleConnectionFailure
+from ansible.module_utils.connection import ConnectionError
+
 
 try:
     from ibmsecurity.appliance.isamappliance import ISAMAppliance
@@ -102,7 +103,7 @@ logger = logging.getLogger(sys.argv[0])
 
 def main():
     if not HAS_IBMSECURITY:
-        raise AnsibleConnectionFailure(
+        raise ConnectionError(
             "Error> ibmsecurity python module required for ibm.isam.isam connection plugin"
         )
     module = AnsibleModule(

--- a/roles/fed/configure_instance_federations/defaults/main.yml
+++ b/roles/fed/configure_instance_federations/defaults/main.yml
@@ -1,2 +1,4 @@
+---
+
 # Provide the following values for this role to work
 import_personal_certs: []

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,0 +1,3 @@
+plugins/modules/isam.py validate-modules:missing-gplv3-license
+plugins/modules/isamadmin.py validate-modules:missing-gplv3-license
+plugins/modules/isamcompare.py validate-modules:missing-gplv3-license

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,0 +1,3 @@
+plugins/modules/isam.py validate-modules:missing-gplv3-license
+plugins/modules/isamadmin.py validate-modules:missing-gplv3-license
+plugins/modules/isamcompare.py validate-modules:missing-gplv3-license


### PR DESCRIPTION
Changed AnsibleConnectionFailure to ansible.module_utils.connection.ConnectionError.
 Ignore files to ignore validate-modules:missing-gplv3-license during ansible-test sanity.