### PR TITLE
Fixes for issues found by ansible-test

### DIFF
--- a/plugins/modules/isamcompare.py
+++ b/plugins/modules/isamcompare.py
@@ -87,7 +87,6 @@ from ansible.module_utils.basic import AnsibleModule
 from io import StringIO
 import datetime
 from ansible.module_utils.six import string_types
-from ansible.module_utils.connection import ConnectionError
 
 
 try:
@@ -103,7 +102,7 @@ logger = logging.getLogger(sys.argv[0])
 
 def main():
     if not HAS_IBMSECURITY:
-        raise ConnectionError(
+        raise ImportError(
             "Error> ibmsecurity python module required for ibm.isam.isam connection plugin"
         )
     module = AnsibleModule(

--- a/tests/sanity/ignore-2.10.txt
+++ b/tests/sanity/ignore-2.10.txt
@@ -1,3 +1,5 @@
 plugins/modules/isam.py validate-modules:missing-gplv3-license
 plugins/modules/isamadmin.py validate-modules:missing-gplv3-license
 plugins/modules/isamcompare.py validate-modules:missing-gplv3-license
+plugins/connection/isam.py pylint:super-with-arguments
+plugins/connection/isam.py pylint:raise-missing-from

--- a/tests/sanity/ignore-2.9.txt
+++ b/tests/sanity/ignore-2.9.txt
@@ -1,3 +1,5 @@
 plugins/modules/isam.py validate-modules:missing-gplv3-license
 plugins/modules/isamadmin.py validate-modules:missing-gplv3-license
 plugins/modules/isamcompare.py validate-modules:missing-gplv3-license
+plugins/connection/isam.py pylint:super-with-arguments
+plugins/connection/isam.py pylint:raise-missing-from


### PR DESCRIPTION
* Updated isamcompare.py to use ImportError instead of ConnectionError. 
* Added to the tests/sanity/ignore files:
plugins/connection/isam.py pylint:super-with-arguments
plugins/connection/isam.py pylint:raise-missing-from

