### PR TITLE
Comment 'install_license_file' in default.yml because it prevents usi…

### DIFF
--- a/roles/install_license/defaults/main.yml
+++ b/roles/install_license/defaults/main.yml
@@ -4,4 +4,4 @@
 
 # Comment to be used for creating a snapshot file
 install_license_comment: "Automated Snapshot Before Installing Product Support License"
-install_license_file: null
+#install_license_file: null


### PR DESCRIPTION
…ng the role without checking prior if variable exists or not

Please review and consider for merge.

This will allow calling the role as follow without specifying "install_license_file":
    - role: install_license
In this case, the role will just skip the action.
This is practical in cases you don't want to install the license support file but don't want to add extra check in the playbook prior calling install_license role. So, this help maintain as generic playbook as possible without unnecessary clutter added in inventories.
