### PR TITLE
Fixed yamllint issues

### DIFF
--- a/roles/add_oauth_definition/tasks/main.yml
+++ b/roles/add_oauth_definition/tasks/main.yml
@@ -24,7 +24,7 @@
       pinLength: "{{ add_oauth_definition_pinLength }}"
       tokenCharSet: "{{ add_oauth_definition_tokenCharSet }}"
       oidc: "{{ add_oauth_definition_oidc }}"
-      accessPolicyName : "{{ add_oauth_definition_accessPolicyName }}"
+      accessPolicyName: "{{ add_oauth_definition_accessPolicyName }}"
   when: add_oauth_definition_name is defined
   notify:
   - Commit Changes

--- a/roles/add_sysaccount_user/tasks/main.yml
+++ b/roles/add_sysaccount_user/tasks/main.yml
@@ -7,7 +7,7 @@
     action: ibmsecurity.isam.base.sysaccount.users.create
     isamapi:
       id: "{{ add_sysaccount_id }}"
-      password : "{{ add_sysaccount_password }}"
+      password: "{{ add_sysaccount_password }}"
       groups: "{{ add_sysaccount_groups }}"
   when: add_sysaccount_id is defined
   notify: Commit Changes

--- a/roles/fed/create_federation_partners/tasks/main.yml
+++ b/roles/fed/create_federation_partners/tasks/main.yml
@@ -33,7 +33,7 @@
           | combine({ 'role': item.1.role } if (item.1.role is defined) else {})
           | combine({ 'configuration': item.1.configuration } if (item.1.configuration is defined) else {})
     }}"
-  with_subelements :
+  with_subelements:
     - "{{ federations }}"
     - partners
     - skip_missing: True


### PR DESCRIPTION
* roles/add_oauth_definition/tasks/main.yml:27:23: colons: too many spaces before colon
* roles/add_sysaccount_user/tasks/main.yml:10:15: colons: too many spaces before colon
* roles/fed/create_federation_partners/tasks/main.yml:36:19: colons: too many spaces before colon