### PR TITLE
Bug fixes: import_person_certificates was missing 'password'

### DIFF
--- a/playbooks/base/import_personal_certificates.yml
+++ b/playbooks/base/import_personal_certificates.yml
@@ -2,7 +2,7 @@
 
 # main task for importing personal certificates
 # Example inventory:
-#     import_personal_certs:
+#     personal_certificates:
 #       - kdb_id: pdsrv
 #         label: wildcard.test.net
 #         cert: "uploads/ssl/wildcard.test.net.p12"
@@ -11,5 +11,5 @@
 - hosts: "{{ hosts | default('all')}}"
   gather_facts: no
   roles:
-    - role: ibm.isam.base/import_personal_certificates
+    - role: ibm.isam.base.import_personal_certificates
       tags: import_personal_certificates

--- a/roles/base/import_personal_certificates/tasks/main.yml
+++ b/roles/base/import_personal_certificates/tasks/main.yml
@@ -8,6 +8,7 @@
     isamapi:
       kdb_id: "{{ item.kdb_id }}"
       label: "{{ item.label }}"
-      cert: "{{ inventory_dir }}/{{ item.cert }}"
+      cert: "{{ item.cert }}"
+      password: "{{ item.password | default(omit) }}"
   with_items: "{{ personal_certificates }}"
   notify: Commit Changes


### PR DESCRIPTION
 roles/base/import_personal_certificates/tasks/main.yml: added 'password' as an option for input.