### PR TITLE
added missing var entry to connection plugin

### DIFF
--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -18,6 +18,7 @@ DOCUMENTATION = """
             - Specifies the remote device FQDN or IP address of the IBM ISAM Appliance to establish a connection to.
           default: inventory_hostname
           vars:
+            - name: inventory_hostname
             - name: ansible_host
             - name: remote_addr
         port:


### PR DESCRIPTION
This fixes the error message:
[WARNING]: The "ibm.isam.isam" connection plugin has an improperly configured remote target value, forcing "inventory_hostname" templated value instead of the string

For more information on the issue see https://github.com/ansible/ansible/pull/77844/commits/a50dcefc2c6417fd956a8d8dec32f763068a011b