### PR TITLE
188 add ssl verification setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,28 @@ In that case, simply setting validate_certs to True is sufficient.
 validate_certs = True
 ```
 
+#### Setting up your Ansible Execution Environment's python
+
+When using an Ansible Execution Environment, the behaviour of the Python Requests module with TLS may become tricky.
+
+You can check what CA bundle Python will use by default.
+
+```bash
+Python 3.9.18 (main, Sep 22 2023, 17:58:34)
+>>> import certifi
+>>> certifi.where()
+'/home/tbosmans/venv/lib64/python3.9/site-packages/certifi/cacert.pem'
+```
+
+The default path will probably point to a keystore within site-packages.
+The problem with that truststore, is that is likely not updated with any trusts you need to add (eg. certificates from you private Certificate Authority)
+
+So you then have a couple of options:
+
+- replace that cacert.pem in your Execution environment with a trust store that contains your certificates
+- configure `verify_ca_path` in ansible.cfg (through ansible-builder or in ansible.cfg in your project directory)
+- configure an environment variable during build (`REQUESTS_CA_BUNDLE`) that points to the container's system ca bundle.  This is the recommended approach.
+
 #### Generate a self signed certificate (development)
 
 Prepare a 'san.cnf' file.
@@ -263,6 +285,9 @@ If this fails with errors indication that the `ibmsecurity` module is missing, y
 ### 5) Prepare a custom execution environment
 
 You can build a custom execution environment, that contains the python prerequisites for the ibm.isam collection.
+
+You may also need to add custom CA trusts to the execution environment (eg. from your private Certificate Authority),
+and you likely want to set the `REQUESTS_CA_BUNDLE` environment variable.
 
 ### 6) Run it on Ansible Automation Platform
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,8 @@ validate_certs = True
 #### Setting up your Ansible Execution Environment's python
 
 When using an Ansible Execution Environment, the behaviour of the Python Requests module with TLS may become tricky.
+Where the Python configuration in a virtual environment may use your certificates correctly, that is most likely not the case in a container.
+
 
 You can check what CA bundle Python will use by default.
 

--- a/README.md
+++ b/README.md
@@ -86,6 +86,76 @@ ansible_isam_port="443"
 - Please submit a pull request on so we can merge your roles into
   the collection.
 
+### 7) TLS Secure connections
+
+Using ibmsecurity v2024.4.5+ enables secure TLS connections.
+
+```ini
+[isam]
+validate_certs = True
+verify_ca_path = /<path_to_pem>/isamAppliance.pem
+```
+
+You can retrieve the certificate of the LMI and store it to use as `verify_ca_path`
+
+    openssl s_client -connect ${HOSTNAME}:${PORT} </dev/null 2>/dev/null | openssl x509 -outform pem > isamAppliance.pem
+
+The best solution is to get a signed certificate from a Certificate Authority that is trusted within your organization's default ca settings.
+In that case, simply setting validate_certs to True is sufficient.
+
+```ini
+[isam]
+validate_certs = True
+```
+
+#### Generate a self signed certificate (development)
+
+Prepare a 'san.cnf' file.
+You could add multiple IP.x addresses in it if you want.
+You can also use DNS.x hostnames instead.
+
+```ini
+[req]
+default_bits  = 2048
+distinguished_name = req_distinguished_name
+req_extensions = req_ext
+x509_extensions = v3_req
+prompt = no
+[req_distinguished_name]
+countryName = US
+stateOrProvinceName = N/A
+localityName = N/A
+organizationName = Self-signed certificate
+commonName = ISVA_LMI
+[req_ext]
+subjectAltName = @alt_names
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+IP.1 = 192.168.42.2
+IP.2 = 192.168.42.3
+```
+
+Using openssl, you can then generate a certificate and public key, and convert it to pkcs12 format .
+
+```bash
+# generate key & cert
+openssl req -x509 -nodes -days 1730 -newkey rsa:2048 -keyout isamlmi_key.pem -out isamlmi_cert.pem -config san.cnf
+
+# extract public key
+openssl x509 -pubkey -noout -in isamlmi_cert.pem > isamAppliance.pem
+
+# turn into a pkcs12
+openssl pkcs12 -export -in isamlmi_cert.pem -inkey isamlmi_key.pem -out isamlmi.p12 -passout pass:<some password>
+```
+
+You can now use the `isamlmi.p12` certificate as your management ssl certificate (for instance , by using Ansible)
+
+```bash
+ansible-playbook ibm.isam.base.configure_management_ssl.yml -e update_management_ssl_cert_cert="$(pwd)/files/isamlmi.p12" -e update_management_ssl_cert_pwd=<password> -i <your inventory>
+```
+
+
 ## Using execution environments (ansible-navigator and/or AAP)
 
 To use the ibm.isam collection with execution environments, you may need to create a custom Execution Environment first.

--- a/changelogs/fragments/188-enable_tls_verification.yml
+++ b/changelogs/fragments/188-enable_tls_verification.yml
@@ -1,0 +1,7 @@
+---
+minor_changes:
+  - refactor naming to YYYY.MM.xx (still semantic versioning)
+  - base/set_management_ssl_cert - remove default LOG value
+
+major_changes:
+  - plugins/connection/isam.py - add verify ssl certificate.  This requires ibmsecurity version

--- a/changelogs/fragments/188-enable_tls_verification.yml
+++ b/changelogs/fragments/188-enable_tls_verification.yml
@@ -1,10 +1,14 @@
 ---
+release_summary: |
+  | Enable use of TLS for the LMI
+
 minor_changes:
   - refactor naming to YYYY.MM.xx (still semantic versioning)
   - base/set_management_ssl_cert - remove default LOG value
+  - documentation updates
 
 major_changes:
-  - plugins/connection/isam.py - add verify ssl certificate.  This requires ibmsecurity version
+  - plugins/connection/isam.py - add verify ssl certificate.  This requires ibmsecurity version v2024.4.5+.
 
 add object.playbook:
   - name: base.configure_management_ssl.yml

--- a/changelogs/fragments/188-enable_tls_verification.yml
+++ b/changelogs/fragments/188-enable_tls_verification.yml
@@ -5,3 +5,7 @@ minor_changes:
 
 major_changes:
   - plugins/connection/isam.py - add verify ssl certificate.  This requires ibmsecurity version
+
+add object.playbook:
+  - name: base.configure_management_ssl.yml
+    description: Playbook to set management ssl certificate

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -10,7 +10,7 @@ namespace: ibm
 name: isam
 
 # The version of the collection. Must be compatible with semantic versioning - use YYYY.MM.xx (where xx is a number)
-version: 2024.4.1
+version: 2024.4.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,8 +9,8 @@ namespace: ibm
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: isam
 
-# The version of the collection. Must be compatible with semantic versioning
-version: 1.1.1
+# The version of the collection. Must be compatible with semantic versioning - use YYYY.MM.xx (where xx is a number)
+version: 2024.4.1
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/galaxy.yml
+++ b/galaxy.yml
@@ -9,8 +9,8 @@ namespace: ibm
 # The name of the collection. Has the same character restrictions as 'namespace'
 name: isam
 
-# The version of the collection. Must be compatible with semantic versioning - use YYYY.MM.xx (where xx is a number)
-version: 2024.4.0
+# The version of the collection. Must be compatible with semantic versioning - use YYYY.MM.xx (where xx is a number, starting at 0)
+version: 2024.6.0
 
 # The path to the Markdown (.md) readme file. This path is relative to the root of the collection
 readme: README.md

--- a/playbooks/base/configure_management_ssl.yml
+++ b/playbooks/base/configure_management_ssl.yml
@@ -1,0 +1,11 @@
+---
+# You need these 2 variables:
+# -e update_management_ssl_cert_cert="files/isamlmi.p12"
+# -e update_management_ssl_cert_pwd=passw0rd
+- name: Set management ssl
+  hosts: all
+  gather_facts: no
+  tasks:
+    - name: "Set management ssl certificate"
+      import_role:
+        name: ibm.isam.base.set_management_ssl_cert

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -195,7 +195,10 @@ class Connection(NetworkConnectionBase):
                 # Will throw an error (not sure which)
                 self.queue_message(
                     'warning',
-                    f"Upgrade your ibmsecurity python module ! \n\nSkipped error is : {e}")
+                    'Upgrade your ibmsecurity python module to 2024.4.5.0 or higher')
+                self.queue_message(
+                    'warning',
+                    f'This error is skipped (backward compatibility): {e}')
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port)
                 pass
 

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -193,7 +193,7 @@ class Connection(NetworkConnectionBase):
                 # Assume this is the old ibmsecurity code, without the verify option
                 # Will throw an error (not sure which)
                 self.queue_message(
-                    'log',
+                    'v',
                     f"Upgrade your ibmsecurity python module ! \n{e}")
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port)
 

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -197,7 +197,7 @@ class Connection(NetworkConnectionBase):
                 # Assume this is the old ibmsecurity code, without the verify option
                 # Will throw an error (not sure which)
                 self.queue_message(
-                    'log',
+                    'warning',
                     f"Upgrade your ibmsecurity python module ! \n{e}")
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port)
 

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -103,7 +103,18 @@ DOCUMENTATION = """
             - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
           vars:
             - name: ansible_persistent_log_messages
-
+        validate_certs:
+          type: bool
+          default: false
+          description: []
+          vars:
+            - name: isam_validate_certs
+          version_added: '2024.4.0'
+        verify_ca_path:
+          type: str
+          required: false
+          description: []
+          version_added: '2024.4.0'
 
 """
 import importlib
@@ -151,7 +162,7 @@ class Connection(NetworkConnectionBase):
             passwd = self.get_option('password')
             verify_ca_path = self.get_option('verify_ca_path')
             verify = self.get_option('validate_certs')
-
+            self.queue_message('log', f'Verify certificates {verify}')
             if verify_ca_path is not None:
                 if verify_ca_path.lower() in ["true", "yes"]:
                     if verify_ca_path.lower() == "true":

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -129,7 +129,6 @@ try:
     # from ibmsecurity.appliance.isamappliance_adminproxy import ISAMApplianceAdminProxy  #  TODO: this is not used currently
     from ibmsecurity.appliance.ibmappliance import IBMError
     from ibmsecurity.user.applianceuser import ApplianceUser
-
     HAS_IBMSECURITY = True
 except ImportError:
     HAS_IBMSECURITY = False
@@ -162,7 +161,7 @@ class Connection(NetworkConnectionBase):
             passwd = self.get_option('password')
             verify_ca_path = self.get_option('verify_ca_path')
             verify = self.get_option('validate_certs')
-            self.queue_message('log', f'Verify certificates {verify}')
+            self.queue_message('vvv', f'Verify certificates {verify}')
             if verify_ca_path is not None:
                 if verify_ca_path.lower() in ["true", "yes"]:
                     if verify_ca_path.lower() == "true":

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -105,7 +105,6 @@ DOCUMENTATION = """
             - name: ansible_persistent_log_messages
         verify_tls:
           type: boolean
-          required: False
           default: False
           description:
             - If V(False), SSL certificate will not be validated for connection to the LMI
@@ -120,7 +119,7 @@ DOCUMENTATION = """
           type: string
           required: False
           description:
-            - If this has a value, verify_tls will also be set to V(True)
+            - If this has a value (a path or true/True), verify_tls will also be set to V(True)
             - This should only contain the path to the public key for the tls connection to the LMI if you're using self-signed certificates
             - Otherwise, this value should not be set
             - If the environment variable is true or false, it's going to override verify_tls as well
@@ -132,6 +131,7 @@ DOCUMENTATION = """
           vars:
             - name: ibmseclib_verify_connection
           version_added: 2024.4.0
+
 """
 import importlib
 

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -105,9 +105,9 @@ DOCUMENTATION = """
             - name: ansible_persistent_log_messages
         validate_certs:
           type: bool
-          default: False
+          default: false
           description:
-            - If V(False), SSL certificate will not be validated for connection to the LMI
+            - If V(false), SSL certificate will not be validated for connection to the LMI
             - This should only set to V(false) used on personally controlled sites using self-signed certificates.
           ini:
             - section: isam
@@ -117,7 +117,7 @@ DOCUMENTATION = """
           version_added: '2024.4.0'
         verify_ca_path:
           type: str
-          required: False
+          required: false
           description:
             - If this has a value (a path or true/True), verify_tls will also be set to V(True)
             - PEM formatted file that contains a CA certificate to be used for validation for the tls connection to the LMI

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -103,25 +103,24 @@ DOCUMENTATION = """
             - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
           vars:
             - name: ansible_persistent_log_messages
-        verify_tls:
-          type: boolean
+        validate_certs:
+          type: bool
           default: False
           description:
             - If V(False), SSL certificate will not be validated for connection to the LMI
             - This should only set to V(false) used on personally controlled sites using self-signed certificates.
           ini:
             - section: isam
-              key: verify_tls
+              key: validate_certs
           vars:
-            - name: isam_verify_tls
-          version_added: 2024.4.0
+            - name: isam_validate_certs
+          version_added: '2024.4.0'
         verify_ca_path:
-          type: string
+          type: str
           required: False
           description:
             - If this has a value (a path or true/True), verify_tls will also be set to V(True)
-            - This should only contain the path to the public key for the tls connection to the LMI if you're using self-signed certificates
-            - Otherwise, this value should not be set
+            - PEM formatted file that contains a CA certificate to be used for validation for the tls connection to the LMI
             - If the environment variable is true or false, it's going to override verify_tls as well
           ini:
             - section: isam
@@ -130,7 +129,7 @@ DOCUMENTATION = """
             - name: IBMSECLIB_VERIFY_CONNECTION
           vars:
             - name: ibmseclib_verify_connection
-          version_added: 2024.4.0
+          version_added: '2024.4.0'
 
 """
 import importlib
@@ -177,7 +176,7 @@ class Connection(NetworkConnectionBase):
             user = self.get_option('user')
             passwd = self.get_option('password')
             verify_ca_path = self.get_option('verify_ca_path')
-            verify = self.get_option('verify_tls')
+            verify = self.get_option('validate_certs')
 
             if verify_ca_path is not None:
                 if verify_ca_path.lower() in ["true", "yes"]:

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -103,33 +103,7 @@ DOCUMENTATION = """
             - name: ANSIBLE_PERSISTENT_LOG_MESSAGES
           vars:
             - name: ansible_persistent_log_messages
-        validate_certs:
-          type: bool
-          default: false
-          description:
-            - If V(false), SSL certificate will not be validated for connection to the LMI
-            - This should only set to V(false) used on personally controlled sites using self-signed certificates.
-          ini:
-            - section: isam
-              key: validate_certs
-          vars:
-            - name: isam_validate_certs
-          version_added: '2024.4.0'
-        verify_ca_path:
-          type: str
-          required: false
-          description:
-            - If this has a value (a path or true/True), verify_tls will also be set to V(True)
-            - PEM formatted file that contains a CA certificate to be used for validation for the tls connection to the LMI
-            - If the environment variable is true or false, it's going to override verify_tls as well
-          ini:
-            - section: isam
-              key: verify_ca_path
-          env:
-            - name: IBMSECLIB_VERIFY_CONNECTION
-          vars:
-            - name: ibmseclib_verify_connection
-          version_added: '2024.4.0'
+
 
 """
 import importlib

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -104,11 +104,13 @@ DOCUMENTATION = """
           vars:
             - name: ansible_persistent_log_messages
         verify_connection:
-          type: boolean
+          type: string
+          required: False
           description:
             - If V(False), SSL certificate will not be validated for connection to the LMI
             - This should only set to V(false) used on personally controlled sites using self-signed certificates.
-          default: False
+            - Set to V(True) for using your default trust store
+            - Set to the path of the public key , in case of self signed certificates
           ini:
             - section: isam
               key: verify_connection
@@ -116,6 +118,7 @@ DOCUMENTATION = """
             - name: IBMSECLIB_VERIFY_CONNECTION
           vars:
             - name: ibmseclib_verify_connection
+          version_added: 2024.4.0
 
 """
 import importlib

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -188,12 +188,16 @@ class Connection(NetworkConnectionBase):
             #    adminProxyApplianceShortName=adminProxyApplianceShortName)
             #    pass
             try:
+                self.queue_message(
+                    'vv',
+                    'TEST')
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port, verify=verify)
+
             except Exception as e:
                 # Assume this is the old ibmsecurity code, without the verify option
                 # Will throw an error (not sure which)
                 self.queue_message(
-                    'v',
+                    'log',
                     f"Upgrade your ibmsecurity python module ! \n{e}")
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port)
 

--- a/plugins/connection/isam.py
+++ b/plugins/connection/isam.py
@@ -188,9 +188,6 @@ class Connection(NetworkConnectionBase):
             #    adminProxyApplianceShortName=adminProxyApplianceShortName)
             #    pass
             try:
-                self.queue_message(
-                    'vv',
-                    'TEST')
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port, verify=verify)
 
             except Exception as e:
@@ -198,8 +195,9 @@ class Connection(NetworkConnectionBase):
                 # Will throw an error (not sure which)
                 self.queue_message(
                     'warning',
-                    f"Upgrade your ibmsecurity python module ! \n{e}")
+                    f"Upgrade your ibmsecurity python module ! \n\nSkipped error is : {e}")
                 self.isam_server = ISAMAppliance(hostname=host, user=u, lmi_port=port)
+                pass
 
             self._sub_plugin = {'name': 'isam_server', 'obj': self.isam_server}
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
+certifi
 ibmsecurity
 python_ldap

--- a/roles/base/set_management_ssl_cert/tasks/main.yml
+++ b/roles/base/set_management_ssl_cert/tasks/main.yml
@@ -1,7 +1,7 @@
 ---
 - name: Update management ssl certificate
   ibm.isam.isam:
-    log: "{{ log_level | default('INFO') }}"
+    log: "{{ log_level | default(omit) }}"
     force: "{{ force | default(False) }}"
     action: ibmsecurity.isam.base.management_ssl_certificate.set
     isamapi:


### PR DESCRIPTION
Updates to ibm.isam collection, so we can use TLS verification of the LMI connection by default.