### PR TITLE
Feature/fido2

### DIFF
--- a/changelogs/fragments/fido2.yml
+++ b/changelogs/fragments/fido2.yml
@@ -2,3 +2,5 @@
 add object.role:
   - name: base.configure_mgmtazn_role
     description: Add role to configure management authorization
+  - name: aac.configure_authentication_policies_json
+    description: Role to configure authentication policies using json format

--- a/changelogs/fragments/fido2.yml
+++ b/changelogs/fragments/fido2.yml
@@ -1,4 +1,7 @@
 ---
+minor_changes:
+  - update molecule tests for fido2
+
 add object.role:
   - name: base.configure_mgmtazn_role
     description: Add role to configure management authorization

--- a/changelogs/fragments/fido2.yml
+++ b/changelogs/fragments/fido2.yml
@@ -1,0 +1,4 @@
+---
+add object.role:
+  - name: base.configure_mgmtazn_role
+    description: Add role to configure management authorization

--- a/changelogs/fragments/fido2.yml
+++ b/changelogs/fragments/fido2.yml
@@ -4,3 +4,5 @@ add object.role:
     description: Add role to configure management authorization
   - name: aac.configure_authentication_policies_json
     description: Role to configure authentication policies using json format
+  - name: aac.get_fido2_relyingparty_configid
+    description: Get the fido2 relying party config id based on name (helper for configuring authentication mechanisms)

--- a/molecule/aac/converge.yml
+++ b/molecule/aac/converge.yml
@@ -56,3 +56,7 @@
         - mmfa
       ansible.builtin.import_role:
         name: ibm.isam.aac.configure_mmfa_pushnotifications
+
+    - name: Configure authentication policies json
+      ansible.builtin.import_role:
+        name: ibm.isam.aac.configure_authentication_policies_json

--- a/molecule/aac/vars/aac.yml
+++ b/molecule/aac/vars/aac.yml
@@ -215,3 +215,46 @@ aac_push_notifications:
       firebase:
         service_account_json: "{'type': 'service_account','project_id': 'ivia-push-test'}" # MUST BE A STRING
         provider_address: "fcm.googleapis.com:443"
+
+# Fido2
+# the hostname must exist, so need to add it to host file of appliance
+# scim, and aac enabled on rp
+fido2:
+  name: www.tommietest.com
+  rpId: www.tommietest.com
+  id: 3a397ef1-ca61-45ff-83f6-10c730bad4d2
+  relyingPartyOptions:
+    impersonationGroup: adminGroup
+    webauthnSpecEnforcement: true
+  fidoServerOptions:
+    origins:
+      - https://www.tommietest.com
+    metadataSet: []
+    metadataSoftFail: true
+    attestation:
+      statementTypes:
+        - basic
+        - self
+        - attCA
+        - anonCA
+        - none
+      statementFormats:
+        - fido-u2f
+        - packed
+        - tpm
+        - android-key
+        - android-safetynet
+        - apple
+        - none
+      publicKeyAlgorithms:
+        - SHA256withECDSA
+        - SHA256withRSA
+      compoundAttestationAllValid: true
+    android-safetynet:
+      attestationMaxAge: 60000
+      clockSkew: 30000
+      ctsProfileMatch: true
+    preferMdsOverStatic: false
+    mdsRefresh: 86400
+    metadataServices: []
+    timeout: 300

--- a/molecule/aac/vars/aac.yml
+++ b/molecule/aac/vars/aac.yml
@@ -258,3 +258,39 @@ fido2:
     mdsRefresh: 86400
     metadataServices: []
     timeout: 300
+
+#
+# Infomaps - policies
+#
+aac_authentication_policies:
+  - name: "test1_scimConfig"
+    description: "test1 - uses an oob mechanism"
+    uri: "urn:ibm:security:authentication:asf:test1"
+    enabled: true
+    policy:
+      - step:
+          mechanism:
+            id: "urn:ibm:security:authentication:asf:mechanism:scimConfig"
+  - name: "MMFA Fingerprint Authentication Response"
+    description: "Enforces fingerprint authentication through a registered MMFA authenticator."
+    uri: "urn:ibm:security:authentication:asf:mmfa_fingerprint_response"
+    enabled: true
+    policy:
+      - step:
+          mechanism:
+            id: "urn:ibm:security:authentication:asf:mechanism:mobile_user_approval:fingerprint"
+      - step:
+          mechanism:
+            id: "urn:ibm:security:authentication:asf:mechanism:mmfa"
+            parameters:
+              - id: "mode"
+                source: "value"
+                value: "Response"
+  - name: "Non existing policy"
+    policy_action: delete
+    uri: "urn:ibm:security:authentication:asf:test2"
+    enabled: true
+    policy:
+      - step:
+          mechanism:
+            id: "urn:ibm:security:authentication:asf:mechanism:mobile_user_approval:fingerprint"

--- a/roles/aac/configure_authentication_policies_json/defaults/main.yml
+++ b/roles/aac/configure_authentication_policies_json/defaults/main.yml
@@ -1,0 +1,7 @@
+---
+
+# Default variables for configuration of authentication policies
+authentication_policies: []
+# Default variables for filtering
+policy_name: "{{ item.name }}"
+policy_action: "{{ item.policy_action }}"

--- a/roles/aac/configure_authentication_policies_json/defaults/main.yml
+++ b/roles/aac/configure_authentication_policies_json/defaults/main.yml
@@ -1,7 +1,3 @@
 ---
-
 # Default variables for configuration of authentication policies
-authentication_policies: []
-# Default variables for filtering
-policy_name: "{{ item.name }}"
-policy_action: "{{ item.policy_action }}"
+aac_authentication_policies: []

--- a/roles/aac/configure_authentication_policies_json/meta/argument_specs.yml
+++ b/roles/aac/configure_authentication_policies_json/meta/argument_specs.yml
@@ -1,0 +1,60 @@
+---
+argument_specs:
+  main:
+    short_description: Configure authentication policies using json policy format
+    description:
+      - This is the main entrypoint for the C(ibm.isam.aac.configure_authentication_policies_json) role.
+    version_added: '3.2.0'
+    author:
+      - 'IBM Security Orchestration <secorch@wwpdl.vnet.ibm.com>'
+    options:
+      aac_authentication_policies:
+        type: "list"
+        elements: "dict"
+        required: false
+        description:
+          - A list of policy objects
+        options:
+          policy_action:
+            type: 'str'
+            choices:
+              - set
+              - delete
+            required: false
+            description: use set or delete
+          name:
+            type: 'str'
+            required: true
+            description: Name of the policy
+          description:
+            type: 'str'
+            required: false
+            description: The description of the policy
+          dialect:
+            type: 'str'
+            required: false
+            default: urn:ibm:security:authentication:policy:1.0:schema
+            description: Optional dialect parameter
+          enabled:
+            type: 'bool'
+            required: false
+            default: true
+            description: Optional is the policy enabled.  Defaults to true
+          uri:
+            type: 'str'
+            required: true
+            description: The full uri for the policy
+          policy:
+            type: 'list'
+            required: true
+            description: The Policy in json format (yaml)
+            elements: 'dict'
+            options:
+              step:
+                type: dict
+                required: false
+                description: Policy Step
+              decision:
+                type: dict
+                required: false
+                description: The Policy decision

--- a/roles/aac/configure_authentication_policies_json/meta/argument_specs.yml
+++ b/roles/aac/configure_authentication_policies_json/meta/argument_specs.yml
@@ -1,7 +1,7 @@
 ---
 argument_specs:
   main:
-    short_description: Configure authentication policies using json policy format
+    short_description: Configure or delete authentication policies using json policy format
     description:
       - This is the main entrypoint for the C(ibm.isam.aac.configure_authentication_policies_json) role.
     version_added: '3.2.0'
@@ -42,12 +42,12 @@ argument_specs:
             description: Optional is the policy enabled.  Defaults to true
           uri:
             type: 'str'
-            required: true
-            description: The full uri for the policy
+            required: false
+            description: The full uri for the policy.  Is required for creating or updating policies.
           policy:
             type: 'list'
-            required: true
-            description: The Policy in json format (yaml)
+            required: false
+            description: The Policy in json format (yaml).  Is required for creating or updating policies.
             elements: 'dict'
             options:
               step:

--- a/roles/aac/configure_authentication_policies_json/meta/main.yml
+++ b/roles/aac/configure_authentication_policies_json/meta/main.yml
@@ -1,0 +1,19 @@
+---
+
+galaxy_info:
+  author: IBM
+  description: Role to configure authentication policies
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: "2.2"
+
+  galaxy_tags:
+    - isam
+    - ibm
+    - configure
+    - authenticationpolicies
+
+dependencies:
+  - ibm.isam.common_handlers

--- a/roles/aac/configure_authentication_policies_json/meta/main.yml
+++ b/roles/aac/configure_authentication_policies_json/meta/main.yml
@@ -1,5 +1,4 @@
 ---
-
 galaxy_info:
   author: IBM
   description: Role to configure authentication policies
@@ -7,13 +6,14 @@ galaxy_info:
 
   license: Apache
 
-  min_ansible_version: "2.2"
+  min_ansible_version: "2.15"
 
   galaxy_tags:
     - isam
     - ibm
     - configure
     - authenticationpolicies
+    - json
 
 dependencies:
   - ibm.isam.common_handlers

--- a/roles/aac/configure_authentication_policies_json/tasks/main.yml
+++ b/roles/aac/configure_authentication_policies_json/tasks/main.yml
@@ -1,81 +1,5 @@
 ---
-# main task to configure authentication policies
-
-- name: Help INFO (-e help=true)
-  ansible.builtin.pause:
-    echo: true
-    prompt: |
-      NAME
-        configure_authentication_policies
-
-      DESCRIPTION
-        Role to configure authentication policies
-
-      STEPS
-        1) Configure authentication policies
-        2) Commit changes
-
-      EXAMPLES
-        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml // configure all authentication policies
-        // run only tasks with set to add or update authentication policies
-        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml -e policy_action=set
-        // run only tasks from authentication_policies inventory where element name equals this parameter
-        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml -e policy_name=test_auth_policy_1
-
-      INVENTORY
-      ==========
-      # configure authentication policies
-      authentication_policies:
-        # create authentication policy
-        # Attention: the PolicyId attribute inside the policy element must be identitcal to the uri element.
-        #            Either use ansible variable or keep them manually in sync!
-        #            e.g. globally define `test_auth_policy_1_uri: urn:ibm:security:authentication:asf:test_auth_policy_1` and
-        #            use {{ '{{' }} test_auth_policy_1_uri {{ '}}' }} inside authentication_policies dict (?)
-        - policy_action: set
-          name: test_auth_policy_1
-          description: Test authentication policy
-          dialect: urn:ibm:security:authentication:policy:1.0:schema
-          enabled: true
-          uri: urn:ibm:security:authentication:asf:test_auth_policy_1
-          policy: '<Policy xmlns="urn:ibm:security:authentication:policy:1.0:schema" PolicyId="urn:ibm:security:authentication:asf:test_auth_policy_1"><Step
-                   type="Authenticator"><Authenticator AuthenticatorId="urn:ibm:security:authentication:asf:mechanism:info_map"/></Step></Policy>'
-
-        # policy provided as yaml (converted with collection filter ibm.isam.to_xml)
-        - policy_action: set
-          name: test_auth_policy_1
-          description: Test authentication policy
-          dialect: urn:ibm:security:authentication:policy:1.0:schema
-          enabled: true
-          uri: urn:ibm:security:authentication:asf:test_auth_policy_1
-          policy:
-            - name: Policy
-              attributes:
-                xmlns: urn:ibm:security:authentication:policy:1.0:schema
-                PolicyId: urn:ibm:security:authentication:asf:test_auth_policy_1
-              children:
-                - name: Step
-                  attributes:
-                    type: Authenticator
-                  children:
-                    - name: Authenticator
-                      attributes:
-                        AuthenticatorId: urn:ibm:security:authentication:asf:mechanism:info_map
-
-        # delete authentication policy
-        - policy_action: delete
-          name: test_auth_policy_1
-      ==========
-
-      INTERACTION
-        ENTER         = continue
-        Ctrl+C + 'C'  = continue
-        Ctrl+C + 'A'  = abort
-  when: help is defined
-
-# def set(isamAppliance, name, policy, uri, description="", dialect="urn:ibm:security:authentication:policy:1.0:schema",
-#        enabled=None, formatting='xml', check_mode=False, force=False):
-
-- name: Configure authentication policies
+- name: Configure authentication policies (JSON)
   ibm.isam.isam:
     log: "{{ log_level | default(omit) }}"
     force: "{{ force | default(omit) }}"
@@ -87,11 +11,21 @@
       description: "{{ item.description | default(omit) }}"
       enabled: "{{ item.enabled | default(omit) }}"
       formatting: 'json'
-  loop: "{{ authentication_policies }}"
+  loop: "{{ aac_authentication_policies }}"
   when:
-    - item.policy_action is defined
-    - item.policy_action == 'set'
-    - item.name == policy_name
+    - (item.policy_action | default('set'))  == 'set'
   loop_control:
-    label: "{'policy_action': {{ item.policy_action }}, 'name': {{ item.name }} }"
+    label: "Set policy {{ item.name | default('') }}"
+  notify: Commit Changes
+
+- name: Remove authentication policies (JSON)
+  ibm.isam.isam:
+    log: "{{ log_level | default(omit) }}"
+    force: "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.authentication.policies.delete
+    isamapi:
+      name: "{{ item.name }}"
+  loop: "{{ aac_authentication_policies | selectattr('policy_action', 'defined') | selectattr('policy_action', 'equalto', 'delete') }}"
+  loop_control:
+    label: "Delete policy {{ item.name | default('') }}"
   notify: Commit Changes

--- a/roles/aac/configure_authentication_policies_json/tasks/main.yml
+++ b/roles/aac/configure_authentication_policies_json/tasks/main.yml
@@ -1,0 +1,97 @@
+---
+# main task to configure authentication policies
+
+- name: Help INFO (-e help=true)
+  ansible.builtin.pause:
+    echo: true
+    prompt: |
+      NAME
+        configure_authentication_policies
+
+      DESCRIPTION
+        Role to configure authentication policies
+
+      STEPS
+        1) Configure authentication policies
+        2) Commit changes
+
+      EXAMPLES
+        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml // configure all authentication policies
+        // run only tasks with set to add or update authentication policies
+        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml -e policy_action=set
+        // run only tasks from authentication_policies inventory where element name equals this parameter
+        ansible-playbook -i [...] ibm.isam.aac.configure_authentication_policies.yml -e policy_name=test_auth_policy_1
+
+      INVENTORY
+      ==========
+      # configure authentication policies
+      authentication_policies:
+        # create authentication policy
+        # Attention: the PolicyId attribute inside the policy element must be identitcal to the uri element.
+        #            Either use ansible variable or keep them manually in sync!
+        #            e.g. globally define `test_auth_policy_1_uri: urn:ibm:security:authentication:asf:test_auth_policy_1` and
+        #            use {{ '{{' }} test_auth_policy_1_uri {{ '}}' }} inside authentication_policies dict (?)
+        - policy_action: set
+          name: test_auth_policy_1
+          description: Test authentication policy
+          dialect: urn:ibm:security:authentication:policy:1.0:schema
+          enabled: true
+          uri: urn:ibm:security:authentication:asf:test_auth_policy_1
+          policy: '<Policy xmlns="urn:ibm:security:authentication:policy:1.0:schema" PolicyId="urn:ibm:security:authentication:asf:test_auth_policy_1"><Step
+                   type="Authenticator"><Authenticator AuthenticatorId="urn:ibm:security:authentication:asf:mechanism:info_map"/></Step></Policy>'
+
+        # policy provided as yaml (converted with collection filter ibm.isam.to_xml)
+        - policy_action: set
+          name: test_auth_policy_1
+          description: Test authentication policy
+          dialect: urn:ibm:security:authentication:policy:1.0:schema
+          enabled: true
+          uri: urn:ibm:security:authentication:asf:test_auth_policy_1
+          policy:
+            - name: Policy
+              attributes:
+                xmlns: urn:ibm:security:authentication:policy:1.0:schema
+                PolicyId: urn:ibm:security:authentication:asf:test_auth_policy_1
+              children:
+                - name: Step
+                  attributes:
+                    type: Authenticator
+                  children:
+                    - name: Authenticator
+                      attributes:
+                        AuthenticatorId: urn:ibm:security:authentication:asf:mechanism:info_map
+
+        # delete authentication policy
+        - policy_action: delete
+          name: test_auth_policy_1
+      ==========
+
+      INTERACTION
+        ENTER         = continue
+        Ctrl+C + 'C'  = continue
+        Ctrl+C + 'A'  = abort
+  when: help is defined
+
+# def set(isamAppliance, name, policy, uri, description="", dialect="urn:ibm:security:authentication:policy:1.0:schema",
+#        enabled=None, formatting='xml', check_mode=False, force=False):
+
+- name: Configure authentication policies
+  ibm.isam.isam:
+    log: "{{ log_level | default(omit) }}"
+    force: "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.authentication.policies.set
+    isamapi:
+      name: "{{ item.name }}"
+      policy: "{{ item.policy }}"
+      uri: "{{ item.uri }}"
+      description: "{{ item.description | default(omit) }}"
+      enabled: "{{ item.enabled | default(omit) }}"
+      formatting: 'json'
+  loop: "{{ authentication_policies }}"
+  when:
+    - item.policy_action is defined
+    - item.policy_action == 'set'
+    - item.name == policy_name
+  loop_control:
+    label: "{'policy_action': {{ item.policy_action }}, 'name': {{ item.name }} }"
+  notify: Commit Changes

--- a/roles/aac/configure_fido2/molecule/default/converge.yml
+++ b/roles/aac/configure_fido2/molecule/default/converge.yml
@@ -12,3 +12,17 @@
     - name: "Testing configure fido2"
       ansible.builtin.include_role:
         name: ibm.isam.aac.configure_fido2
+
+    - name: Get configid
+      vars:
+        aac_fido2_relyingparty_name: "DEMO"
+      ansible.builtin.include_role:
+        name: ibm.isam.aac.get_fido2_relyingparty_configid
+
+    - name: Debug
+      ansible.builtin.debug:
+        var:  aac_fido2_relyingparty_id.data
+
+    - name: Configure fido2 webauthn registration
+      ansible.builtin.include_role:
+        name: ibm.isam.aac.configure_authentication_mechanisms

--- a/roles/aac/configure_fido2/molecule/vars/main.yml
+++ b/roles/aac/configure_fido2/molecule/vars/main.yml
@@ -8,15 +8,12 @@ fido2_configurations:
   - fido2_action: metadata.get
     name: metadata.json
   # Export specific metadata to disc
-  - fido2_action: metadata.export_file
+  - fido2_action: metadata.export_file # this doens't do anything
     name: metadata.json
     filename: ../files/metadata.json
   # Delete specific metadata entry by name
   - fido2_action: metadata.delete
     name: metadata.json
-  # Import metadata from disc
-  - fido2_action: metadata.import_file
-    filename: ../files/metadata.json
   # Retrieve all FIDO2 configurations of all relying parties
   - fido2_action: relying_parties.get_all
   # Retrieve entire FIDO2 configruation of a specific relying party
@@ -24,9 +21,6 @@ fido2_configurations:
     name: DEMO
   # Retrieve only FIDO2 relying party ID on the appliance
   - fido2_action: relying_parties.search
-    name: DEMO
-  # Delete a FIDO2 relying party
-  - fido2_action: relying_parties.delete
     name: DEMO
   # Create or update fido2 relying party
   # set will call add (new relying party) or update (existing relying party) respectivly with a config comparisson prior to the execution of the change
@@ -60,19 +54,40 @@ fido2_configurations:
       android-safetynet:
         attestationMaxAge: 60000
         clockSkew: 30000
-
-  # Retrieve all FIDO2 registrations
-  - fido2_action: registrations.get_all
   # Retrieve a specific FIDO2 registration for a given credentialId
   - fido2_action: registrations.get
     credentialId: CKYuA1IJW4wY-FnKY_gLubEfaqEJK6_6E4t8I_JWgmE
+  # Retrieve all FIDO2 registrations
+  - fido2_action: registrations.get_all
   # Delete all FIDO2 registrations for a given username
   - fido2_action: registrations.delete
     username: testuser01
-
+  # Delete a FIDO2 relying party TODO: does not work
+  #- fido2_action: relying_parties.delete
+  #  name: DEMO
   # Retrieve a count of U2F Registrations yet to be migrated
   - fido2_action: u2f_migration.get_all
   # Migrate U2F Registrations
   - fido2_action: u2f_migration.migrate
     batchSize: '1000' # The number of registrations to migrate in a single batch
     batchCount: '5' # The number of batches to migrate. Can be set to 'all' to indicate that all registrations should be migrated.
+  # Import metadata from disk - TODO: this does not work
+  # - fido2_action: metadata.import_file
+  #  filename: files/metadata.json
+
+authentication_mechanisms:
+  - mechanism_action: set
+    name: "FIDO2 WebAuthn Registration"
+    description: "Performs the FIDO2/WebAuthn Attestation Ceremony"
+    typeName: "FIDO2AuthenticatorName"
+    uri: "urn:ibm:security:authentication:asf:mechanism:fido2registration"
+    attributes: []
+    properties:
+      - key: "FIDO2.abortOnError"
+        value: "false"
+      - key: "FIDO2.optionsTemplate"
+        value: "/authsvc/authenticator/fido/default_attestation_options.json"
+      - key: "FIDO2.templatePage"
+        value: "/authsvc/authenticator/fido/attestation.html"
+      - key: "FIDO2.relyingPartyConfigId"
+        value: "{{ aac_fido2_relyingparty_id.data }}"

--- a/roles/aac/get_fido2_relyingparty_configid/defaults/main.yml
+++ b/roles/aac/get_fido2_relyingparty_configid/defaults/main.yml
@@ -1,0 +1,2 @@
+---
+# defaults file

--- a/roles/aac/get_fido2_relyingparty_configid/meta/argument_specs.yml
+++ b/roles/aac/get_fido2_relyingparty_configid/meta/argument_specs.yml
@@ -1,0 +1,14 @@
+---
+argument_specs:
+  main:
+    short_description: Get the configid from a fido2 relying party
+    description:
+      - This is the main entrypoint for the C(ibm.isam.aac.get_fido2_relyingparty_configid) role.
+    author:
+      - 'IBM Security Orchestration <secorch@wwpdl.vnet.ibm.com>'
+    options:
+      aac_fido2_relyingparty_name:
+        type: str
+        required: true
+        description:
+          - "The name of the fido2 relying party"

--- a/roles/aac/get_fido2_relyingparty_configid/meta/main.yml
+++ b/roles/aac/get_fido2_relyingparty_configid/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: IBM
+  description: Retrieve fido2 relying party id
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: "2.15"
+
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - ibm
+    - isam
+    - fido2
+    - passkeys
+    - get
+
+dependencies: []

--- a/roles/aac/get_fido2_relyingparty_configid/tasks/main.yml
+++ b/roles/aac/get_fido2_relyingparty_configid/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+# tasks file
+- name: Get fido2 relying party configid by name
+  ibm.isam.isam:
+    log: "{{ log_level | default(omit) }}"
+    force: "{{ force | default(omit) }}"
+    action: ibmsecurity.isam.aac.fido2.relying_parties.search
+    isamapi:
+      name: "{{ aac_fido2_relyingparty_name }}"
+  when:
+    - aac_fido2_relyingparty_name is defined
+  register: aac_fido2_relyingparty_id

--- a/roles/base/configure_mgmtazn_role/README.md
+++ b/roles/base/configure_mgmtazn_role/README.md
@@ -1,0 +1,302 @@
+# Configure mgmtazn role
+
+This role creates a management authorization role and configures it.
+
+I updated the code to allow all configuration in 1 go (2022.06.08 or something)
+
+```
+management_authorization_roles:
+  - name: some_role_1
+    groups:
+      - name: existinggroup
+        type: local
+    users:
+      - name: admin1
+        type: local
+    features:
+      - name: "wpm_policy_administration"
+        access: "w"
+    role_action: add
+```
+
+The construct needs to match the json format of the management authorization api.
+Below is a sample
+
+```
+        {
+            "users": null,
+            "groups": null,
+            "features": [
+                {
+                    "name": "events.page_title",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_manage_log_files",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_application_logs",
+                    "access": "w"
+                },
+                {
+                    "name": "audit_configuration_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_runtime_tracing_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "memory_graph",
+                    "access": "w"
+                },
+                {
+                    "name": "cpu_graph",
+                    "access": "w"
+                },
+                {
+                    "name": "storage_graph",
+                    "access": "w"
+                },
+                {
+                    "name": "application_interfaces_statistics",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_reverse_proxy_traffic",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_reverse_proxy_throughput",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_common_components",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_instances",
+                    "access": "w"
+                },
+                {
+                    "name": "authz_instances",
+                    "access": "w"
+                },
+                {
+                    "name": "dsc_admin",
+                    "access": "w"
+                },
+                {
+                    "name": "wpm_policy_administration",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_dynamic_url",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_jmt",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_um_cdas",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_unm_cdas",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_pwd_strength",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_forms_based_sso",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_http_tran",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_kerberos_config",
+                    "access": "w"
+                },
+                {
+                    "name": "rsa_config",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_isam_key",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_menu_ltpa_key_files",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_access_control_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_authentication_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_risk_profiles_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_attributes_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_obligations_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_api_protection_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_pip_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_extensions_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_devices_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "runtime_database_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_advanced_config",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_user_registry",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_runtime_parameters_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mga_template_files",
+                    "access": "w"
+                },
+                {
+                    "name": "mga_mapping_rules",
+                    "access": "w"
+                },
+                {
+                    "name": "mga_access_policies",
+                    "access": "w"
+                },
+                {
+                    "name": "alias_settings_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "mobile_server_connections_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "tfim_federations",
+                    "access": "w"
+                },
+                {
+                    "name": "tfim_sts",
+                    "access": "w"
+                },
+                {
+                    "name": "manage_attribute_source",
+                    "access": "w"
+                },
+                {
+                    "name": "alias_service",
+                    "access": "w"
+                },
+                {
+                    "name": "grants",
+                    "access": "w"
+                },
+                {
+                    "name": "manage_partner_templates",
+                    "access": "w"
+                },
+                {
+                    "name": "geolocation_data_menu",
+                    "access": "w"
+                },
+                {
+                    "name": "network_configuration",
+                    "access": "r"
+                },
+                {
+                    "name": "felb",
+                    "access": "r"
+                },
+                {
+                    "name": "hosts_file",
+                    "access": "r"
+                },
+                {
+                    "name": "webseal_packet_tracing",
+                    "access": "w"
+                },
+                {
+                    "name": "cluster_configuration",
+                    "access": "r"
+                },
+                {
+                    "name": "applog_lang",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_kdb",
+                    "access": "w"
+                },
+                {
+                    "name": "webseal_file_downloads",
+                    "access": "r"
+                },
+                {
+                    "name": "apollo",
+                    "access": "w"
+                },
+                {
+                    "name": "scim_configuration",
+                    "access": "w"
+                },
+                {
+                    "name": "rsyslog_forwarder",
+                    "access": "w"
+                },
+                {
+                    "name": "push_notification_registration",
+                    "access": "w"
+                },
+                {
+                    "name": "mga_mmfa_config",
+                    "access": "w"
+                },
+                {
+                    "name": "mga_point_of_contact",
+                    "access": "w"
+                },
+                {
+                    "name": "trial",
+                    "access": "w"
+                }
+            ],
+            "name": "Security Administrator"
+        },
+
+```

--- a/roles/base/configure_mgmtazn_role/defaults/main.yml
+++ b/roles/base/configure_mgmtazn_role/defaults/main.yml
@@ -1,0 +1,10 @@
+---
+# Provide a list of features and access for this role to work on
+# management_authorization_roles:
+#  - name: role_1
+#    groups: []
+#    users: []
+#    features:
+#      - name: "wpm_policy_administration"
+#        access: "w"
+#    action: set

--- a/roles/base/configure_mgmtazn_role/meta/main.yml
+++ b/roles/base/configure_mgmtazn_role/meta/main.yml
@@ -1,0 +1,23 @@
+---
+galaxy_info:
+  author: IBM
+  description: Role that sets a feature in role for Management Authorization
+  company: IBM
+
+  license: Apache
+
+  min_ansible_version: "2.15"
+  platforms:
+    - name: GenericLinux
+      versions:
+        - all
+
+  galaxy_tags:
+    - isam
+    - ibm
+    - managementauthorization
+    - role
+    - feature
+
+dependencies:
+  - role: ibm.isam.common_handlers

--- a/roles/base/configure_mgmtazn_role/tasks/main.yml
+++ b/roles/base/configure_mgmtazn_role/tasks/main.yml
@@ -1,0 +1,17 @@
+---
+- name: Set Management Authorization Roles
+  ibm.isam.isam:
+    log: "{{ log_level | default('INFO') }}"
+    force: "{{ force | default(False) }}"
+    action: ibmsecurity.isam.base.management_authorization.role.{{ item.action | default('set') }}
+    isamapi:
+      name: "{{ item.name }}"
+      users: "{{ item.users | default(omit) }}"
+      groups: "{{ item.groups | default(omit) }}"
+      features: "{{ item.features | default(omit) }}"
+  loop: "{{ management_authorization_roles }}"
+  loop_control:
+    label: "Role: {{ item.action | default('set') }} {{ item.name | default('') }}"
+  when:
+    - management_authorization_roles is defined
+  notify: Commit Changes


### PR DESCRIPTION
minor changes:
  - update molecule tests for fido2

new roles:
  - name: base.configure_mgmtazn_role
    description: Add role to configure management authorization
  - name: aac.configure_authentication_policies_json
    description: Role to configure authentication policies using json format
  - name: aac.get_fido2_relyingparty_configid
    description: Get the fido2 relying party config id based on name (helper for configuring authentication mechanisms)