### PR TITLE
Remove get_md5 parameter in the ansible.builtin.stat module from the install_firmware role

### DIFF
--- a/roles/install_firmware/tasks/main.yml
+++ b/roles/install_firmware/tasks/main.yml
@@ -3,7 +3,6 @@
   ansible.builtin.stat:
     path: "{{ install_firmware_file }}"
     get_checksum: false
-    get_md5: false
   register: firmware
 
 - name: Upload Firmware file - {{ install_firmware_file }}


### PR DESCRIPTION
The following task in the install_firmware role contains the parameter **get_md5: false** for the **ansible.builtin.stat** module, taht is not available in the module
---
- name: Check if Firmware Upgrade file exists - {{ install_firmware_file }}
  ansible.builtin.stat:
    path: "{{ install_firmware_file }}"
    get_checksum: false
    get_md5: false
  register: firmware